### PR TITLE
autoexec: fixed --check not detecting dash on different path

### DIFF
--- a/source/autoexec/autoexec
+++ b/source/autoexec/autoexec
@@ -237,7 +237,7 @@ while :; do
 					*/env\ sh|*/sh)
 						File=`type -P sh`
 						Link=`realpath "$File"`
-						if [[ $Link == /bin/dash ]]; then
+						if [[ ${Link##*/} == dash ]]; then
 							$Exec -n "$ExecFile" || Errors='True'
 						else
 							UnsupportedCheck='True'


### PR DESCRIPTION
On Debian 11 dash is found under /usr/bin/dash. This should fix it.